### PR TITLE
Maybe support recaptcha.net

### DIFF
--- a/src/recaptcha.nim
+++ b/src/recaptcha.nim
@@ -37,8 +37,6 @@ const
 </noscript>"""
 
 type
-  Language* = enum
-    EN, CN
   ReCaptcha* = object
     ## reCAPTCHA client information, used to render the reCAPTCHA input and verify user responses.
     secret: string


### PR DESCRIPTION
It's unable to visit https://www.google.com/recaptcha/api/siteverify in China.For example, people in China can't register Nim Forum because google is banned.
So Maybe can replace this url  with https://recaptcha.net/recaptcha/api/siteverify when detected Country.


Infos can be found in https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally
List below:

Can I use reCAPTCHA globally?
Yes, please use "www.recaptcha.net" in your code in circumstances when "www.google.com" is not accessible.

First, replace <script src="https://www.google.com/recaptcha/api.js" async defer></script> with <script src="https://www.recaptcha.net/recaptcha/api.js" async defer></script>
After that, apply the same to everywhere else that uses "www.google.com/recaptcha/" on your site.