### PR TITLE
Implement support for hCaptcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # reCAPTCHA
 
-reCAPTCHA support for Nim, supporting rendering a capctcha and verifying a user's response.
+reCAPTCHA support for Nim, supporting rendering a capctcha and verifying a user's response. This library supports reCaptcha from:
+* https://www.google.com/recaptcha/admin
+* https://recaptcha.net
+* https://hcaptcha.com
 
 ## Installation
 
@@ -10,14 +13,18 @@ nimble install recaptcha
 
 ## Usage
 
-Before using this modul, be sure to [register your site with Google](https://www.google.com/recaptcha/admin) in order to get your client secret and site key. These are required to use this module.
+Before using this modul, be sure to register at the reCaptcha providers website in order to get your client secret and site key. These are required to use this module. Register at:
+* [Google reCaptcha](https://www.google.com/recaptcha/admin)
+* [hCaptcha](https://hcaptcha.com)
 
 Once you have your client secret and site key, you should create an instance of `ReCaptcha`:
 
 ```nim
 import recaptcha
 
-let captcha = initReCaptcha(MY_SECRET_KEY, MY_SITE_KEY)
+let captcha = initReCaptcha("MY_SECRET_KEY", "MY_SITE_KEY", Google)
+#let captcha = initReCaptcha("MY_SECRET_KEY", "MY_SITE_KEY", RecaptchaNet) <-- using recaptcha.net
+#let captcha = initReCaptcha("MY_SECRET_KEY", "MY_SITE_KEY", Hcaptcha)     <-- using hcaptcha.com
 ```
 
 You can print out the required HTML code to show the reCAPTCHA element on the page using the `render` method:
@@ -25,7 +32,7 @@ You can print out the required HTML code to show the reCAPTCHA element on the pa
 ```nim
 import recaptcha
 
-let captcha = initReCaptcha(MY_SECRET_KEY, MY_SITE_KEY)
+let captcha = initReCaptcha("MY_SECRET_KEY", "MY_SITE_KEY", Google)
 
 echo captcha.render()
 ```
@@ -37,7 +44,7 @@ Once the user has submitted the captcha back to you, you should verify their res
 ```nim
 import recaptcha, asyncdispatch
 
-let captcha = initReCaptcha(MY_SECRET_KEY, MY_SITE_KEY)
+let captcha = initReCaptcha("MY_SECRET_KEY", "MY_SITE_KEY", Google)
 
 let response = await captcha.verify(THEIR_RESPONSE)
 ```
@@ -46,14 +53,49 @@ If the user is a valid user, `response` will be `true`. Otherwise, it will be `f
 
 Should there be an issue with the data sent to the reCAPTCHA service, an exception of type `CaptchaVerificationError` will be thrown.
 
-In most cases, captchas are used within a HTML `<form>` element. In this case, the user's response will be available within the `g-recaptcha-response` form parameter.
+In most cases, captchas are used within a HTML `<form>` element. In this case, the user's response will be available within form parameter named `g-recaptcha-response` for `Google` and `reCaptha.net` and within `h-recaptcha-repsonse` for `hCaptcha`.
 
 You may also optionally pass the user's IP address along to reCAPTCHA during verification as an extra check:
 
 ```nim
 import recaptcha, asyncdispatch
 
-let captcha = initReCaptcha(MY_SECRET_KEY, MY_SITE_KEY)
+let captcha = initReCaptcha("MY_SECRET_KEY", "MY_SITE_KEY", Google)
 
 let response = await captcha.verify(THEIR_RESPONSE, USERS_IP_ADDRESS)
+```
+
+# Example
+
+The example below uses `Google` as validator.
+
+```nim
+import recaptcha, asyncdispatch, jester
+from strutils import format
+
+const htmlForm = """
+<form method="POST" action="/verify">
+  <input type="text" name="email">
+  <input type="password" name="password">
+  <div class="g-recaptcha" data-sitekey="$1"></div>
+  <button type="submit">Verify</button>
+  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+</form>
+"""
+
+let 
+  secretKey = "123456789"
+  siteKey   = "987654321"
+  captcha   = initReCaptcha(secretKey, siteKey, Google)
+
+routes:
+  get "/login":
+    resp(htmlForm.format(siteKey))
+
+  post "/verify":
+    let checkCap = await captcha.verify(@"g-recaptcha-response")
+    if checkCap:
+      resp("Welcome")
+    else:
+      resp("You failed the captcha")
 ```

--- a/src/recaptcha.nim
+++ b/src/recaptcha.nim
@@ -61,15 +61,27 @@ type
   CaptchaVerificationError* = object of Exception
     ## Error thrown if something goes wrong whilst attempting to verify a captcha response.
 
-proc initReCaptcha*(secret, siteKey: string, replace = false): ReCaptcha =
+proc initReCaptcha*(secret, siteKey: string, provider: Provider = Google): ReCaptcha =
   ## Initialise a ReCaptcha instance with the given secret key and site key.
   ##
   ## The secret key and site key can be generated at https://www.google.com/recaptcha/admin
   result = ReCaptcha(
     secret: secret,
     siteKey: siteKey,
-    replace: replace
+    provider: provider
   )
+
+proc initReCaptcha*(secret, siteKey: string, replace = false): ReCaptcha {.deprecated.} =
+  ## Initialise a ReCaptcha instance with the given secret key and site key.
+  ##
+  ## The secret key and site key can be generated at https://www.google.com/recaptcha/admin
+  let provider = if replace: Google else: RecaptchaNet
+  result = ReCaptcha(
+    secret: secret,
+    siteKey: siteKey,
+    provider: provider
+  )
+
 
 proc render*(rc: ReCaptcha, includeNoScript: bool = false): string =
   ## Render the required code to display the captcha.

--- a/src/recaptcha.nim
+++ b/src/recaptcha.nim
@@ -152,7 +152,7 @@ proc verify*(rc: ReCaptcha, reCaptchaResponse, remoteIp: string): Future[bool] {
     "response": reCaptchaResponse,
     "remoteip": remoteIp
   })
-  result = await checkVerification(multiPart, rc.replace)
+  result = await checkVerification(multiPart, rc.provider)
 
 proc verify*(rc: ReCaptcha, reCaptchaResponse: string): Future[bool] {.async.} =
   ## Verify the given reCAPTCHA response.
@@ -160,7 +160,7 @@ proc verify*(rc: ReCaptcha, reCaptchaResponse: string): Future[bool] {.async.} =
     "secret": rc.secret,
     "response": reCaptchaResponse,
   })
-  result = await checkVerification(multiPart, rc.replace)
+  result = await checkVerification(multiPart, rc.provider)
 
 when not defined(nimdoc) and isMainModule:
   import os, jester

--- a/src/recaptcha.nim
+++ b/src/recaptcha.nim
@@ -199,7 +199,7 @@ when not defined(nimdoc) and isMainModule:
       secretKey = getEnv("RECAPTCHA_SECRET")
       siteKey = getEnv("RECAPTCHA_SITEKEY")
 
-    captcha = initReCaptcha(secretKey, siteKey)
+    captcha = initReCaptcha(secretKey, siteKey, Google)
 
     runForever()
 

--- a/src/recaptcha.nim
+++ b/src/recaptcha.nim
@@ -2,14 +2,23 @@
 
 import asyncdispatch, httpclient, json
 
+type
+  Provider* = enum
+    Google
+    RecaptchaNet
+    Hcaptcha
+
 const
   VerifyUrl: string = "https://www.google.com/recaptcha/api/siteverify"
-  VerifyUrlReplace: string = "https://recaptcha.net/recaptcha/api/siteverify"
-  CaptchaScript: string = r"""<script src="https://www.google.com/recaptcha/api.js" async defer></script>"""
-  CaptchaScriptReplace: string = r"""<script src="https://recaptcha.net/recaptcha/api.js" async defer></script>"""
-  CaptchaElementStart: string = r"""<div class="g-recaptcha" data-sitekey=""""
-  CaptchaElementEnd: string = r""""></div>"""
-  NoScriptElementStart: string = r"""<noscript>
+  VerifyUrlRecaptchaNet: string = "https://recaptcha.net/recaptcha/api/siteverify"
+  VerifyUrlhCaptcha: string = "https://hcaptcha.com/siteverify"
+  CaptchaScript*: string = """<script src="https://www.google.com/recaptcha/api.js" async defer></script>"""
+  CaptchaScriptRecaptchaNet*: string = """<script src="https://recaptcha.net/recaptcha/api.js" async defer></script>"""
+  CaptchaScriptHcaptcha*: string = """<script src="https://hcaptcha.com/1/api.js" async defer></script>"""
+  CaptchaElementStart: string = """<div class="g-recaptcha" data-sitekey=""""
+  CaptchaElementStartHcaptcha: string = """<div class="h-captcha" data-sitekey=""""
+  CaptchaElementEnd: string = """"></div>"""
+  NoScriptElementStart: string = """<noscript>
   <div>
     <div style="width: 302px; height: 422px; position: relative;">
       <div style="width: 302px; height: 422px; position: absolute;">
@@ -43,7 +52,9 @@ type
       ## The reCAPTCHA secret key.
     siteKey: string
       ## The reCAPTCHA site key.
-    replace: bool
+    provider: Provider
+      ## The catpcha provider: Google, reCaptchaNet, hCaptcha
+    replace {.deprecated.}: bool 
       ## Default use www.google.com.If true, use "www.recaptcha.net".
       ## Docs in https://developers.google.com/recaptcha/docs/faq#can-i-use-recaptcha-globally.
 

--- a/src/recaptcha.nim
+++ b/src/recaptcha.nim
@@ -92,7 +92,7 @@ proc render*(rc: ReCaptcha, includeNoScript: bool = false): string =
   if rc.provider == Hcaptcha:
     result = CaptchaElementStartHcaptcha
   else:
-  result = CaptchaElementStart
+    result = CaptchaElementStart
   result.add(rc.siteKey)
   result.add(CaptchaElementEnd)
   result.add("\n")

--- a/src/recaptcha.nim
+++ b/src/recaptcha.nim
@@ -89,18 +89,23 @@ proc render*(rc: ReCaptcha, includeNoScript: bool = false): string =
   ## If you set `includeNoScript` to `true`, then the `<noscript>` element required to support browsers without JS will be included in the output.
   ## By default, this is disabled as you have to modify the settings for your reCAPTCHA domain to set the security level to the minimum level to support this.
   ## For more information, see the reCAPTCHA support page: https://developers.google.com/recaptcha/docs/faq#does-recaptcha-support-users-that-dont-have-javascript-enabled
+  if rc.provider == Hcaptcha:
+    result = CaptchaElementStartHcaptcha
+  else:
   result = CaptchaElementStart
   result.add(rc.siteKey)
   result.add(CaptchaElementEnd)
   result.add("\n")
-  if not rc.replace:
+  if rc.provider == Google:
     result.add(CaptchaScript)
-  else:
-    result.add(CaptchaScriptReplace)
+  elif rc.provider == RecaptchaNet:
+    result.add(CaptchaScriptRecaptchaNet)
+  elif rc.provider == Hcaptcha:
+    result.add(CaptchaScriptHcaptcha)
 
-  if includeNoScript:
+  if includeNoScript and rc.provider != Hcaptcha:
     result.add("\n")
-    if not rc.replace:
+    if rc.provider == Google:
       result.add(NoScriptElementStart)
     else:
       result.add(NoScriptElementStartReplace)


### PR DESCRIPTION
This PR implements support for [hCaptcha](https://www.hcaptcha.com/) which is an alternative to Googles reCAPTHCA. I was thinking about making a separate repo for hCaptcha, but I like the thought, that this Nim-library will be the goto lib for captchas. But the the repo-name might be a bit misleading (??). 
Let me know what you think - otherwise I'll go with a separate repo.

The main change in the code is, that we dont use the `rc.replace` but use `rc.provider`, which is pointing to `Provider* = enum` instead.

* https://docs.hcaptcha.com/
* Cloudfare announces they were moving fro reCAPTCHA to hCaptcha in a [blogpost](https://blog.cloudflare.com/moving-from-recaptcha-to-hcaptcha/). 

## Test code:
https://dashboard.hcaptcha.com/signup
```nim
import jester, asyncdispatch, strutils
import src/recaptcha

let
  siteKey = "2345678"
  secretKey = "1234567"
  
var cap = initReCaptcha(secretKey, siteKey, Hcaptcha)

echo cap.render()
routes:
  get "/":
    resp("""<div>
      <form method="POST" action="/verify">
        <div class="h-captcha" data-sitekey="$1"></div>
        $2
        <button type="submit">Validate</button>
      </form>
    </div>
    """.format(siteKey, CaptchaScriptHcaptcha))

  post "/verify":
    let v = @"h-captcha-response"

    if await cap.verify(v):
      resp("OK")
    else:
      resp("ERROR")
```